### PR TITLE
Inspect concrete scalar values in MulLinearOperator/DivLinearOperator

### DIFF
--- a/lineax/_operator.py
+++ b/lineax/_operator.py
@@ -208,8 +208,7 @@ class AbstractLinearOperator(eqx.Module):
         return AddLinearOperator(self, -other)
 
     def __mul__(self, other) -> "AbstractLinearOperator":
-        other = jnp.asarray(other)
-        if other.shape != ():
+        if np.ndim(other) != 0:
             raise ValueError("Can only multiply AbstractLinearOperators by scalars.")
         return MulLinearOperator(self, other)
 
@@ -222,8 +221,7 @@ class AbstractLinearOperator(eqx.Module):
         return ComposedLinearOperator(self, other)
 
     def __truediv__(self, other) -> "AbstractLinearOperator":
-        other = jnp.asarray(other)
-        if other.shape != ():
+        if np.ndim(other) != 0:
             raise ValueError("Can only divide AbstractLinearOperators by scalars.")
         return DivLinearOperator(self, other)
 
@@ -1043,7 +1041,7 @@ class MulLinearOperator(AbstractLinearOperator):
     """
 
     operator: AbstractLinearOperator
-    scalar: Scalar
+    scalar: ArrayLike
 
     def mv(self, vector):
         return (self.operator.mv(vector) ** ω * self.scalar).ω
@@ -1105,7 +1103,7 @@ class DivLinearOperator(AbstractLinearOperator):
     """
 
     operator: AbstractLinearOperator
-    scalar: Scalar
+    scalar: ArrayLike
 
     def mv(self, vector):
         with jax.numpy_dtype_promotion("standard"):

--- a/lineax/_operator.py
+++ b/lineax/_operator.py
@@ -2375,9 +2375,15 @@ def _(operator):
     return conj(operator.operator1) + conj(operator.operator2)
 
 
+def _scalar_conj(scalar):
+    if isinstance(scalar, (int, float, np.ndarray, np.generic)):
+        return np.conj(scalar)
+    return jnp.conj(scalar)
+
+
 @conj.register(MulLinearOperator)
 def _(operator):
-    return conj(operator.operator) * jnp.conj(operator.scalar)
+    return conj(operator.operator) * _scalar_conj(operator.scalar)
 
 
 @conj.register(NegLinearOperator)
@@ -2387,7 +2393,7 @@ def _(operator):
 
 @conj.register(DivLinearOperator)
 def _(operator):
-    return conj(operator.operator) / jnp.conj(operator.scalar)
+    return conj(operator.operator) / _scalar_conj(operator.scalar)
 
 
 @conj.register(ComposedLinearOperator)

--- a/lineax/_operator.py
+++ b/lineax/_operator.py
@@ -2377,7 +2377,7 @@ def _(operator):
 
 @conj.register(MulLinearOperator)
 def _(operator):
-    return conj(operator.operator) * operator.scalar.conj()
+    return conj(operator.operator) * jnp.conj(operator.scalar)
 
 
 @conj.register(NegLinearOperator)
@@ -2387,7 +2387,7 @@ def _(operator):
 
 @conj.register(DivLinearOperator)
 def _(operator):
-    return conj(operator.operator) / operator.scalar.conj()
+    return conj(operator.operator) / jnp.conj(operator.scalar)
 
 
 @conj.register(ComposedLinearOperator)

--- a/lineax/_operator.py
+++ b/lineax/_operator.py
@@ -2127,10 +2127,10 @@ def _(operator):
 @has_unit_diagonal.register(MulLinearOperator)
 @has_unit_diagonal.register(DivLinearOperator)
 def _(operator):
-    try:
-        return float(operator.scalar) == 1.0 and has_unit_diagonal(operator.operator)
-    except Exception:
+    scalar = operator.scalar
+    if not isinstance(scalar, (int, float, np.ndarray, np.generic)):
         return False
+    return float(scalar) == 1.0 and has_unit_diagonal(operator.operator)
 
 
 class _ScalarSign(enum.Enum):
@@ -2141,11 +2141,10 @@ class _ScalarSign(enum.Enum):
 
 
 def _scalar_sign(scalar) -> _ScalarSign:
-    """Returns the sign of a scalar, or unknown for traced JAX values."""
-    try:
-        scalar = float(scalar)
-    except Exception:
+    """Returns the sign of a scalar, or unknown for JAX arrays."""
+    if not isinstance(scalar, (int, float, np.ndarray, np.generic)):
         return _ScalarSign.unknown
+    scalar = float(scalar)
     if scalar > 0:
         return _ScalarSign.positive
     elif scalar < 0:

--- a/lineax/_operator.py
+++ b/lineax/_operator.py
@@ -2141,16 +2141,17 @@ class _ScalarSign(enum.Enum):
 
 
 def _scalar_sign(scalar) -> _ScalarSign:
-    """Returns the sign of a scalar, or unknown for JAX arrays."""
-    if not isinstance(scalar, (int, float, np.ndarray, np.generic)):
-        return _ScalarSign.unknown
-    scalar = float(scalar)
-    if scalar > 0:
-        return _ScalarSign.positive
-    elif scalar < 0:
-        return _ScalarSign.negative
+    """Returns the sign of a scalar, or unknown for JAX tracers."""
+    if isinstance(scalar, (int, float, np.ndarray, np.generic)):
+        scalar = float(scalar)
+        if scalar > 0:
+            return _ScalarSign.positive
+        elif scalar < 0:
+            return _ScalarSign.negative
+        else:
+            return _ScalarSign.zero
     else:
-        return _ScalarSign.zero
+        return _ScalarSign.unknown
 
 
 # PSD/NSD for MulLinearOperator: depends on sign of scalar

--- a/lineax/_operator.py
+++ b/lineax/_operator.py
@@ -35,6 +35,7 @@ from jaxtyping import (
     Inexact,
     PyTree,  # pyright: ignore
     Scalar,
+    ScalarLike,
     Shaped,
 )
 
@@ -1041,7 +1042,7 @@ class MulLinearOperator(AbstractLinearOperator):
     """
 
     operator: AbstractLinearOperator
-    scalar: ArrayLike
+    scalar: ScalarLike
 
     def mv(self, vector):
         return (self.operator.mv(vector) ** ω * self.scalar).ω
@@ -1103,7 +1104,7 @@ class DivLinearOperator(AbstractLinearOperator):
     """
 
     operator: AbstractLinearOperator
-    scalar: ArrayLike
+    scalar: ScalarLike
 
     def mv(self, vector):
         with jax.numpy_dtype_promotion("standard"):

--- a/lineax/_operator.py
+++ b/lineax/_operator.py
@@ -34,7 +34,6 @@ from jaxtyping import (
     ArrayLike,
     Inexact,
     PyTree,  # pyright: ignore
-    Scalar,
     ScalarLike,
     Shaped,
 )

--- a/lineax/_operator.py
+++ b/lineax/_operator.py
@@ -2119,12 +2119,20 @@ for check in (
         return check(operator.operator)
 
 
-# has_unit_diagonal is NOT preserved by scaling or negation
-@has_unit_diagonal.register(MulLinearOperator)
+# has_unit_diagonal is NOT preserved by negation
 @has_unit_diagonal.register(NegLinearOperator)
-@has_unit_diagonal.register(DivLinearOperator)
 def _(operator):
     return False
+
+
+# has_unit_diagonal is preserved by scaling/dividing only when scalar == 1
+@has_unit_diagonal.register(MulLinearOperator)
+@has_unit_diagonal.register(DivLinearOperator)
+def _(operator):
+    try:
+        return float(operator.scalar) == 1.0 and has_unit_diagonal(operator.operator)
+    except Exception:
+        return False
 
 
 class _ScalarSign(enum.Enum):
@@ -2135,17 +2143,17 @@ class _ScalarSign(enum.Enum):
 
 
 def _scalar_sign(scalar) -> _ScalarSign:
-    """Returns the sign of a scalar, or unknown for JAX tracers."""
-    if isinstance(scalar, (int, float, np.ndarray, np.generic)):
+    """Returns the sign of a scalar, or unknown for traced JAX values."""
+    try:
         scalar = float(scalar)
-        if scalar > 0:
-            return _ScalarSign.positive
-        elif scalar < 0:
-            return _ScalarSign.negative
-        else:
-            return _ScalarSign.zero
-    else:
+    except Exception:
         return _ScalarSign.unknown
+    if scalar > 0:
+        return _ScalarSign.positive
+    elif scalar < 0:
+        return _ScalarSign.negative
+    else:
+        return _ScalarSign.zero
 
 
 # PSD/NSD for MulLinearOperator: depends on sign of scalar


### PR DESCRIPTION
_scalar_sign previously used isinstance checks that excluded JAX concrete
arrays (e.g. jnp.array(2.0)), returning unknown even when the value is
inspectable. Switch to float() with try/except so any concrete scalar —
Python primitive, numpy scalar, or concrete JAX array — is handled, while
traced JAX values inside jit still conservatively return unknown.

Also fix has_unit_diagonal for MulLinearOperator/DivLinearOperator: it
was always False, but scaling or dividing by exactly 1.0 preserves the
unit-diagonal property.

https://claude.ai/code/session_01WBKdLy5422YHh4Kq2cr3QM